### PR TITLE
Added comments starting with double slash to the grammar

### DIFF
--- a/grammars/vcl.cson
+++ b/grammars/vcl.cson
@@ -120,6 +120,10 @@
         'match': '(#).*$\\n?'
         'name': 'comment.line.vcl'
       }
+      {
+        'match': '(//).*$\\n?'
+        'name': 'comment.line.vcl'
+      }
     ]
   'function-invocation':
     'captures':


### PR DESCRIPTION
Hi,
According to the docs (https://www.varnish-cache.org/docs/trunk/reference/vcl.html#comments) single line comments can start either with # or //, so I added the latter to the grammar definition.
