### PR TITLE
Add missing conditional keywords

### DIFF
--- a/grammars/vcl.cson
+++ b/grammars/vcl.cson
@@ -203,7 +203,7 @@
         'name': 'keyword.control.vcl.action'
       }
       {
-        'begin': '\\b(if|elseif)\\s*\\((.+)\\)\\s*(\\{\\s*|$)'
+        'begin': '\\b(if|elseif|elsif|elif|else if)\\s*\\((.+)\\)\\s*(\\{\\s*|$)'
         'captures':
           '1':
             'name': 'keyword.control.vcl.if'


### PR DESCRIPTION
The conditional keywords "elsif/elif/else if" are also allowed.

http://www.varnish-cache.org/docs/trunk/reference/vcl.html